### PR TITLE
Add Datadog configuration inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,23 @@ To do that pull the action from a branch.
 
 ## Inputs
 
-| Input                              | Description                                                                                                     | Required | Default |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|---------|
-| gresb-test-version                 | The version of gresb-test to use.                                                                               | true     |         |
-| cmd-args                           | The arguments passed to gresb-test.                                                                             | true     | '-V'    |
-| installation-github-pat            | The GitHub token used for downloading the installation script.                                                  | true     |         |
-| installation-aws-access-key-id     | The AWS access key id used to install gresb-test. Needs access to the gresb-application-versions S3 bucket.     | true     |         |
-| installation-aws-secret-access-key | The AWS secret access key used to install gresb-test. Needs access to the gresb-application-versions S3 bucket. | true     |         |
-| test-aws-access-key-id             | The AWS access key id used to run tests that require interaction with AWS APIs.                                 | false    |         |
-| test-aws-secret-access-key         | The AWS secret access key used to run tests that require interaction with AWS APIs.                             | false    |         |
-| test-mailtrap-token                | The Mailtrap token used to run tests that require interaction with Mailtrap APIs.                               | false    |         |
-| test-slack-token                   | The Slack token used to run tests that require interaction with Slack APIs.                                     | false    |         |
-| test-gresb-portal-user-password    | The password for the default test user in the portal.                                                           | false    |         |
-| cluster-api-key                    | The Kafka cluster api key                                                                                       | false    |         |
-| cluster-api-secret                 | The Kafka cluster api secret                                                                                    | false    |         | 
+| Input                              | Description                                                                                                     | Required | Default      |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|--------------|
+| gresb-test-version                 | The version of gresb-test to use.                                                                               | true     |              |
+| cmd-args                           | The arguments passed to gresb-test.                                                                             | true     | '-V'         |
+| installation-github-pat            | The GitHub token used for downloading the installation script.                                                  | true     |              |
+| installation-aws-access-key-id     | The AWS access key id used to install gresb-test. Needs access to the gresb-application-versions S3 bucket.     | true     |              |
+| installation-aws-secret-access-key | The AWS secret access key used to install gresb-test. Needs access to the gresb-application-versions S3 bucket. | true     |              |
+| test-aws-access-key-id             | The AWS access key id used to run tests that require interaction with AWS APIs.                                 | false    |              |
+| test-aws-secret-access-key         | The AWS secret access key used to run tests that require interaction with AWS APIs.                             | false    |              |
+| test-mailtrap-token                | The Mailtrap token used to run tests that require interaction with Mailtrap APIs.                               | false    |              |
+| test-slack-token                   | The Slack token used to run tests that require interaction with Slack APIs.                                     | false    |              |
+| test-gresb-portal-user-password    | The password for the default test user in the portal.                                                           | false    |              |
+| test-cluster-api-key               | The Kafka cluster api key                                                                                       | false    |              |
+| test-cluster-api-secret            | The Kafka cluster api secret                                                                                    | false    |              | 
+| test-datadog-api-key               | The Datadog API key.                                                                                            | false    |              | 
+| test-datadog-app-key               | The Datadog APP key.                                                                                            | false    |              | 
+| test-datadog-site                  | The Datadog site.                                                                                               | false    | datadoghq.eu | 
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,16 @@ inputs:
   cluster-api-secret:
     description: 'The Kafka cluster api secret'
     required: false
+  test-datadog-api-key:
+    description: 'The Datadog API key'
+    required: false
+  test-datadog-app-key:
+    description: 'The Datadog APP key'
+    required: false
+  test-datadog-site:
+    description: 'The Datadog site'
+    required: false
+    default: 'datadoghq.eu'
 outputs:
   log:
     description: 'The test log.'
@@ -113,6 +123,9 @@ runs:
         GRESB_PORTAL_PASSWORD: ${{ inputs.test-gresb-portal-user-password }}
         CLUSTER_API_KEY: ${{ inputs.cluster-api-key }}
         CLUSTER_API_SECRET: ${{ inputs.cluster-api-secret }}
+        DD_API_KEY: ${{ inputs.test-datadog-api-key }}
+        DD_APP_KEY: ${{ inputs.test-datadog-app-key }}
+        DD_SITE: ${{ inputs.test-datadog-site }}
     - name: Set status
       shell: bash
       if: always()

--- a/action.yaml
+++ b/action.yaml
@@ -32,10 +32,10 @@ inputs:
   test-gresb-portal-user-password:
     description: 'The password for the default test user in the portal.'
     required: false
-  cluster-api-key:
+  test-cluster-api-key:
     description: 'The Kafka cluster api key'
     required: false
-  cluster-api-secret:
+  test-cluster-api-secret:
     description: 'The Kafka cluster api secret'
     required: false
   test-datadog-api-key:
@@ -121,8 +121,8 @@ runs:
         SLACK_TOKEN: ${{ inputs.test-slack-token }}
         GRESB_RUN_HEADLESS: "true"
         GRESB_PORTAL_PASSWORD: ${{ inputs.test-gresb-portal-user-password }}
-        CLUSTER_API_KEY: ${{ inputs.cluster-api-key }}
-        CLUSTER_API_SECRET: ${{ inputs.cluster-api-secret }}
+        CLUSTER_API_KEY: ${{ inputs.test-cluster-api-key }}
+        CLUSTER_API_SECRET: ${{ inputs.test-cluster-api-secret }}
         DD_API_KEY: ${{ inputs.test-datadog-api-key }}
         DD_APP_KEY: ${{ inputs.test-datadog-app-key }}
         DD_SITE: ${{ inputs.test-datadog-site }}

--- a/action.yaml
+++ b/action.yaml
@@ -33,19 +33,19 @@ inputs:
     description: 'The password for the default test user in the portal.'
     required: false
   test-cluster-api-key:
-    description: 'The Kafka cluster api key'
+    description: 'The Kafka cluster api key.'
     required: false
   test-cluster-api-secret:
-    description: 'The Kafka cluster api secret'
+    description: 'The Kafka cluster api secret.'
     required: false
   test-datadog-api-key:
-    description: 'The Datadog API key'
+    description: 'The Datadog API key.'
     required: false
   test-datadog-app-key:
-    description: 'The Datadog APP key'
+    description: 'The Datadog APP key.'
     required: false
   test-datadog-site:
-    description: 'The Datadog site'
+    description: 'The Datadog site.'
     required: false
     default: 'datadoghq.eu'
 outputs:


### PR DESCRIPTION
This PR adds Datadog input parameters to the action, and then exports them to the `gresb-test` execution environment.