### PR TITLE
Support test automation app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To do that pull the action from a branch.
 
 | Input                              | Description                                                                                                     | Required | Default                    |
 |------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|----------------------------|
+| application-command                | The command name for executing the application.                                                                 | true     | gresb-test                 |
 | gresb-test-version                 | The version of gresb-test to use.                                                                               | true     |                            |
 | cmd-args                           | The arguments passed to gresb-test.                                                                             | true     | "-V"                       |
 | installation-github-pat            | The GitHub token used for downloading the installation script.                                                  | true     |                            |
@@ -41,7 +42,7 @@ To do that pull the action from a branch.
 | test-datadog-app-key               | The Datadog APP key.                                                                                            | false    |                            |
 | test-datadog-site                  | The Datadog site.                                                                                               | false    | "datadoghq.eu"             |
 | test-github-token                  | The GitHub token used by the tests.                                                                             | false    |                            |
-| test-onepassword-svc-vault-token   | The OnePassword service vault token.                                                  | true     |                            |
+| test-onepassword-svc-vault-token   | The OnePassword service vault token.                                                                            | true     |                            |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # action-gresb-test
 
 GitHub Action to install and execute gresb-test.
-This is a composite action that combines other actions, like:
+This is a composite action that combines other actions like:
 
 - actions/setup-java@v3
 - awalsh128/cache-apt-pkgs-action@v1.1.2
@@ -11,38 +11,38 @@ This action is used to install and execute
 the [GRESB integration test tool called `gresb-test`](https://github.com/GRESB/test-automation).
 
 This repository has no CI/CD workflows because the repository is public and the workflows would need GRESB credentials to execute. 
-Therefore in order to test changes to this action, do it from a private repository that uses it.
-To do that pull the action from a branch.
+Therefore, to test changes to this action, do it from a private repository that uses it.
+To do that, pull the action from a branch.
 ```yaml
     - uses: GRESB/action-gresb-test@<branch-name>
 ```
 
 ## Inputs
 
-| Input                              | Description                                                                                                     | Required | Default                    |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|----------------------------|
-| application-command                | The command name for executing the application.                                                                 | true     | gresb-test                 |
-| gresb-test-version                 | The version of gresb-test to use.                                                                               | true     |                            |
-| cmd-args                           | The arguments passed to gresb-test.                                                                             | true     | "-V"                       |
-| installation-github-pat            | The GitHub token used for downloading the installation script.                                                  | true     |                            |
-| installation-aws-access-key-id     | The AWS access key id used to install gresb-test. Needs access to the gresb-application-versions S3 bucket.     | false    |                            |
-| installation-aws-secret-access-key | The AWS secret access key used to install gresb-test. Needs access to the gresb-application-versions S3 bucket. | false    |                            |
-| installation-aws-role-arn          | The AWS IAM role used to install gresb-test. Needs access to the gresb-application-versions S3 bucket.          | false    |                            |
-| installation-aws-role-session-name | The session name used when getting the token.                                                                   | false    | "github-action-gresb-test" |
-| test-aws-access-key-id             | The AWS access key id used to run tests that require interaction with AWS APIs.                                 | false    |                            |
-| test-aws-secret-access-key         | The AWS secret access key used to run tests that require interaction with AWS APIs.                             | false    |                            |
-| test-aws-role-arn                  | The AWS IAM role arn used to run tests that require interaction with AWS APIs.                                  | false    |                            |
-| test-aws-role-session-name         | The session name used when getting the token.                                                                   | false    | "github-action-gresb-test" |
-| test-mailtrap-token                | The Mailtrap token used to run tests that require interaction with Mailtrap APIs.                               | false    |                            |
-| test-slack-token                   | The Slack token used to run tests that require interaction with Slack APIs.                                     | false    |                            |
-| test-gresb-portal-user-password    | The password for the default test user in the portal.                                                           | false    |                            |
-| test-cluster-api-key               | The Kafka cluster api key                                                                                       | false    |                            |
-| test-cluster-api-secret            | The Kafka cluster api secret                                                                                    | false    |                            |
-| test-datadog-api-key               | The Datadog API key.                                                                                            | false    |                            |
-| test-datadog-app-key               | The Datadog APP key.                                                                                            | false    |                            |
-| test-datadog-site                  | The Datadog site.                                                                                               | false    | "datadoghq.eu"             |
-| test-github-token                  | The GitHub token used by the tests.                                                                             | false    |                            |
-| test-onepassword-svc-vault-token   | The OnePassword service vault token.                                                                            | true     |                            |
+| Input                              | Description                                                                                                          | Required | Default                    |
+|------------------------------------|----------------------------------------------------------------------------------------------------------------------|----------|----------------------------|
+| application-command                | The command name for executing the application.                                                                      | true     | gresb-test                 |
+| application-version                | The application version to use.                                                                                      | true     |                            |
+| cmd-args                           | The arguments passed to the application.                                                                             | true     | '-V'                       |
+| installation-github-pat            | The GitHub token used for downloading the installation script.                                                       | true     |                            |
+| installation-aws-access-key-id     | The AWS access key id used to install the application. Needs access to the gresb-application-versions S3 bucket.     | true     |                            |
+| installation-aws-secret-access-key | The AWS secret access key used to install the application. Needs access to the gresb-application-versions S3 bucket. | true     |                            |
+| installation-aws-role-arn          | The AWS IAM role used to install the application. Needs access to the gresb-application-versions S3 bucket.          | false    |                            |
+| installation-aws-role-session-name | The session name used when getting the token.                                                                        | false    | "github-action-gresb-test" |
+| test-aws-access-key-id             | The AWS access key id used to run tests that require interaction with AWS APIs.                                      | false    |                            |
+| test-aws-secret-access-key         | The AWS secret access key used to run tests that require interaction with AWS APIs.                                  | false    |                            |
+| test-aws-role-arn                  | The AWS IAM role arn used to run tests that require interaction with AWS APIs.                                       | false    |                            |
+| test-aws-role-session-name         | The session name used when getting the token.                                                                        | false    | "github-action-gresb-test" |
+| test-mailtrap-token                | The Mailtrap token used to run tests that require interaction with Mailtrap APIs.                                    | false    |                            |
+| test-slack-token                   | The Slack token used to run tests that require interaction with Slack APIs.                                          | false    |                            |
+| test-gresb-portal-user-password    | The password for the default test user in the portal.                                                                | false    |                            |
+| test-cluster-api-key               | The Kafka cluster api key                                                                                            | false    |                            |
+| test-cluster-api-secret            | The Kafka cluster api secret                                                                                         | false    |                            | 
+| test-datadog-api-key               | The Datadog API key.                                                                                                 | false    |                            | 
+| test-datadog-app-key               | The Datadog APP key.                                                                                                 | false    |                            | 
+| test-datadog-site                  | The Datadog site.                                                                                                    | false    | datadoghq.eu               | 
+| test-github-token                  | The GitHub token used by the tests.                                                                                  | false    |                            |
+| test-onepassword-svc-vault-token   | The OnePassword service vault token.                                                                                 | true     |                            |
 
 ## Outputs
 
@@ -53,7 +53,7 @@ To do that pull the action from a branch.
 
 ## Usage
 
-The following workflow configuration installs and executes gresb-test on every pull request commit.
+The following workflow configuration installs and executes the application on every pull request commit.
 
 ```yaml
 name: Continues Integration
@@ -74,7 +74,7 @@ jobs:
         id: test
         uses: ./
         with:
-          gresb-test-version: v0.30.0
+          application-version: v0.30.0
           cmd-args: '-a portal -i main -m browser'
           installation-github-pat: ${{ secrets.BOT_PAT }}
           installation-aws-access-key-id: ${{ secrets.INSTALL_AWS_ACCESS_KEY_ID }}

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: 'The command name for executing the application.'
     required: true
     default: 'gresb-test'
-  gresb-test-version:
+  application-version:
     description: 'The version of gresb-test to use.'
     required: true
   cmd-args:
@@ -96,7 +96,7 @@ runs:
         path: |
           /usr/local/GRESB/${{ inputs.application-command }}
           /usr/local/bin/${{ inputs.application-command }}
-        key: ${{ runner.os }}-${{ inputs.application-command }}-${{ inputs.gresb-test-version }}
+        key: ${{ runner.os }}-${{ inputs.application-command }}-${{ inputs.application-version }}
         restore-keys: ${{ runner.os }}-${{ inputs.application-command }}
     - name: AWS credentials for installation
       uses: aws-actions/configure-aws-credentials@v4
@@ -124,7 +124,7 @@ runs:
         fi
       env:
         cmd: ${{ inputs.application-command }}
-        gresb_test_version: ${{ inputs.gresb-test-version }}
+        gresb_test_version: ${{ inputs.application-version }}
         pat: ${{ inputs.installation-github-pat }}
     - name: AWS credentials for tests
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,10 @@
 name: 'GRESB Test'
 description: 'Run GRESB integration tests'
 inputs:
+  application-command:
+    description: 'The command name for executing the application.'
+    required: true
+    default: 'gresb-test'
   gresb-test-version:
     description: 'The version of gresb-test to use.'
     required: true
@@ -75,7 +79,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Java for gresb-test
+    - name: Install Java
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
@@ -86,14 +90,14 @@ runs:
       with:
         packages: colorized-logs
         version: 1.0
-    - name: Cache gresb-test
-      uses: actions/cache@v4
+    - name: Cache application
+      uses: actions/cache@v3
       with:
         path: |
-          /usr/local/GRESB/gresb-test
-          /usr/local/bin/gresb-test
-        key: ${{ runner.os }}-gresb-test-${{ inputs.gresb-test-version }}
-        restore-keys: ${{ runner.os }}-gresb-test
+          /usr/local/GRESB/${{ inputs.application-command }}
+          /usr/local/bin/${{ inputs.application-command }}
+        key: ${{ runner.os }}-${{ inputs.application-command }}-${{ inputs.gresb-test-version }}
+        restore-keys: ${{ runner.os }}-${{ inputs.application-command }}
     - name: AWS credentials for installation
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -102,23 +106,24 @@ runs:
         role-session-name: ${{ inputs.installation-aws-role-session-name }}
         aws-access-key-id: ${{ inputs.installation-aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.installation-aws-secret-access-key }}
-    - name: Install gresb-test
+    - name: Install application
       shell: bash
       run: |
-        if ! (which gresb-test) || ! (gresb-test -V | grep "${gresb_test_version}"); then
-          echo "DEBUG :: which gresb-test = $( which gresb-test )"
-          echo "DEBUG :: gresb-test -V    = $( gresb-test -V )"
+        if ! (which ${cmd}) || ! (${cmd} -V | grep "${gresb_test_version}"); then
+          echo "DEBUG :: which ${cmd} = $( which ${cmd} )"
+          echo "DEBUG :: ${cmd} -V    = $( ${cmd} -V )"
 
           install_script=/tmp/install.sh
           curl -H "Authorization: token ${pat}" -o "${install_script}" "https://raw.githubusercontent.com/GRESB/test-automation/${gresb_test_version}/test-runner/install.sh"
           chmod +x "${install_script}"
-          echo "==> Installing gresb-test ${gresb_test_version}"
+          echo "==> Installing ${cmd} ${gresb_test_version}"
           "${install_script}" "${gresb_test_version}"
           rm -f "${install_script}"
         else
-          echo "==> gresb-test ${gresb_test_version} already installed"
+          echo "==> ${cmd} ${gresb_test_version} already installed"
         fi
       env:
+        cmd: ${{ inputs.application-command }}
         gresb_test_version: ${{ inputs.gresb-test-version }}
         pat: ${{ inputs.installation-github-pat }}
     - name: AWS credentials for tests
@@ -133,7 +138,7 @@ runs:
       id: run-tests
       shell: bash
       run: |
-        cmd="gresb-test ${cmd_args}"
+        cmd="${cmd} ${cmd_args}"
         echo "DEBUG :: executing = ${cmd}"
         output_file=".output.txt"
         set +e
@@ -147,6 +152,7 @@ runs:
           echo "${END_OF_VALUE}"
         } >> "${GITHUB_OUTPUT}"
       env:
+        cmd: ${{ inputs.application-command }}
         cmd_args: ${{ inputs.cmd-args }}
         MAILTRAP_TOKEN: ${{ inputs.test-mailtrap-token }}
         SLACK_TOKEN: ${{ inputs.test-slack-token }}


### PR DESCRIPTION
With the forking of the GRESB/test-automation repository, this action will need to support two applications `test-automation` and `gresb-test`. This PR adds the parameters required to do that.