### PR TITLE
Fix syntax error using secrets keyword (#patch)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -164,7 +164,7 @@ runs:
         DD_APP_KEY: ${{ inputs.test-datadog-app-key }}
         DD_SITE: ${{ inputs.test-datadog-site }}
         GITHUB_TOKEN: ${{ inputs.test-github-token }}
-        OP_SVC_VAULT_TOKEN: ${{ secrets.test-onepassword-svc-vault-token }}
+        OP_SVC_VAULT_TOKEN: ${{ inputs.test-onepassword-svc-vault-token }}
     - name: Upload test artifacts
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
This PR fixes a syntax error stemming from a rebase conflict. The error is that the `secrets` keyword is not valid in `action.yaml`.