### PR TITLE
Use application name to interpolate URL for test runner installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a composite action that combines other actions like:
 - actions/cache@v3
 
 This action is used to install and execute
-the [GRESB integration test tool called `gresb-test`](https://github.com/GRESB/test-automation).
+the [GRESB integration test tool called `gresb-test`](https://github.com/GRESB/gresb-test).
 
 This repository has no CI/CD workflows because the repository is public and the workflows would need GRESB credentials to execute. 
 Therefore, to test changes to this action, do it from a private repository that uses it.

--- a/action.yaml
+++ b/action.yaml
@@ -114,7 +114,7 @@ runs:
           echo "DEBUG :: ${cmd} -V    = $( ${cmd} -V )"
 
           install_script=/tmp/install.sh
-          curl -H "Authorization: token ${pat}" -o "${install_script}" "https://raw.githubusercontent.com/GRESB/test-automation/${gresb_test_version}/test-runner/install.sh"
+          curl -H "Authorization: token ${pat}" -o "${install_script}" "https://raw.githubusercontent.com/GRESB/${application_command}/${gresb_test_version}/test-runner/install.sh"
           chmod +x "${install_script}"
           echo "==> Installing ${cmd} ${gresb_test_version}"
           "${install_script}" "${gresb_test_version}"
@@ -123,8 +123,9 @@ runs:
           echo "==> ${cmd} ${gresb_test_version} already installed"
         fi
       env:
-        cmd: ${{ inputs.application-command }}
+        application_command: ${{ inputs.application-command }}
         gresb_test_version: ${{ inputs.application-version }}
+        cmd: ${{ inputs.application-command }}
         pat: ${{ inputs.installation-github-pat }}
     - name: AWS credentials for tests
       uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
This PR fixes an issue when installing the test runner tool. The URL where the test runner install script was downloaded from was hardcoded to `test-automation`. This PR replaces that with interpolation of the application name in that URL.