### PR TITLE
Export log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ To do that, pull the action from a branch.
 
 ## Outputs
 
-| Output | Description   |
-|--------|---------------|
-| log    | The test log. |
+| Output   | Description            |
+|----------|------------------------|
+| log_tail | The test log(limited). |
 
 
 ## Usage

--- a/action.yaml
+++ b/action.yaml
@@ -106,7 +106,7 @@ runs:
     - name: AWS credentials for installation
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region:  eu-central-1
+        aws-region: eu-central-1
         role-to-assume: ${{ inputs.installation-aws-role-arn }}
         role-session-name: ${{ inputs.installation-aws-role-session-name }}
         aws-access-key-id: ${{ inputs.installation-aws-access-key-id }}
@@ -135,7 +135,7 @@ runs:
     - name: AWS credentials for tests
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-region:  eu-central-1
+        aws-region: eu-central-1
         role-to-assume: ${{ inputs.test-aws-role-arn }}
         role-session-name: ${{ inputs.test-aws-role-session-name }}
         aws-access-key-id: ${{ inputs.test-aws-access-key-id }}
@@ -180,8 +180,8 @@ runs:
         DD_SITE: ${{ inputs.test-datadog-site }}
         GITHUB_TOKEN: ${{ inputs.test-github-token }}
         OP_SVC_VAULT_TOKEN: ${{ inputs.test-onepassword-svc-vault-token }}
-          
-          - name: Upload test artifacts
+
+    - name: Upload test artifacts
       uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -77,9 +77,10 @@ inputs:
     description: 'The OnePassword service vault token.'
     required: true
 outputs:
-  log:
-    description: 'The test log.'
-    value: ${{ steps.run-tests.outputs.log }}
+  log_tail:
+    description: 'Tail of the test log (truncated).'
+    value: ${{ steps.run-tests.outputs.log_tail }}
+
 runs:
   using: "composite"
   steps:
@@ -145,15 +146,24 @@ runs:
       run: |
         cmd="${cmd} ${cmd_args}"
         echo "DEBUG :: executing = ${cmd}"
+        
         output_file=".output.txt"
+        
         set +e
+        set -o pipefail
         ${cmd} 2>&1 | ansi2txt | tee "${output_file}"
-        status=$?
+        status=${PIPESTATUS[0]}
+        set +o pipefail
+        
+        # Always export status (small)
+        echo "status=${status}" >> "${GITHUB_OUTPUT}"
+        
+        # Export only a small tail of the log (avoid output size limits)
+        MAX_BYTES=50000
+        END_OF_VALUE=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
-          echo "status=${status}"
-          END_OF_VALUE=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "log<<${END_OF_VALUE}";
-          cat "${output_file}";
+          echo "log_tail<<${END_OF_VALUE}"
+          tail -c "${MAX_BYTES}" "${output_file}" || true
           echo "${END_OF_VALUE}"
         } >> "${GITHUB_OUTPUT}"
       env:
@@ -170,7 +180,8 @@ runs:
         DD_SITE: ${{ inputs.test-datadog-site }}
         GITHUB_TOKEN: ${{ inputs.test-github-token }}
         OP_SVC_VAULT_TOKEN: ${{ inputs.test-onepassword-svc-vault-token }}
-    - name: Upload test artifacts
+          
+          - name: Upload test artifacts
       uses: actions/upload-artifact@v4
       if: always()
       with:
@@ -179,6 +190,7 @@ runs:
           screenshots/
           traces/
           TEST-junit-*.xml
+          .output.txt
         retention-days: 5
     - name: Set status
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -162,9 +162,12 @@ runs:
         MAX_BYTES=50000
         END_OF_VALUE=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
-          echo "log_tail<<${END_OF_VALUE}"
-          tail -c "${MAX_BYTES}" "${output_file}" || true
-          echo "${END_OF_VALUE}"
+         {
+           echo "log_tail<<${END_OF_VALUE}"
+           tail -c "${MAX_BYTES}" "${output_file}" || true
+           echo
+           echo "${END_OF_VALUE}"
+         } >> "${GITHUB_OUTPUT}"
         } >> "${GITHUB_OUTPUT}"
       env:
         cmd: ${{ inputs.application-command }}


### PR DESCRIPTION
In `test-automation` we bumped into `The template is not valid. System.InvalidOperationException: Maximum object size exceeded` error. This error means that the GHA workflow template is exceeding the limit. I have tried shortening workflows in many ways in `test-automation` but no success. It is possible that the output log produced by job in this repo is too big. 

With this pr we expose only log tail as output. We upload whole log as artifact if any consumer needs it.